### PR TITLE
upgraded temporal sdk version, added decoded history

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ subprojects {
     ext {
         otelVersion = '1.26.0'
         otelVersionAlpha = "${otelVersion}-alpha"
-        javaSDKVersion = '1.22.2'
+        javaSDKVersion = '1.24.3'
         jarVersion = '1.0.0'
     }
 

--- a/workflowHistories/happy-path-ui-decoded.json
+++ b/workflowHistories/happy-path-ui-decoded.json
@@ -1,0 +1,683 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": "2024-08-15T15:32:12.188686062Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "version": "1302",
+      "taskId": "46418609",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "moneyTransferWorkflow"
+        },
+        "taskQueue": {
+          "name": "MoneyTransferSampleJava24",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJzY2VuYXJpbyI6IkhBUFBZX1BBVEgiLCJhbW91bnQiOjF9"
+            }
+          ]
+        },
+        "workflowExecutionTimeout": "0s",
+        "workflowRunTimeout": "0s",
+        "workflowTaskTimeout": "10s",
+        "originalExecutionRunId": "fe0bd52a-7085-4bd8-a975-c45c3a1d7d1b",
+        "identity": "33939@Steves-MacBook-Pro.local",
+        "firstExecutionRunId": "fe0bd52a-7085-4bd8-a975-c45c3a1d7d1b",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": "0s",
+        "header": {},
+        "workflowId": "TRANSFER-UZB-793"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": "2024-08-15T15:32:12.188805814Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "version": "1302",
+      "taskId": "46418610",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "MoneyTransferSampleJava24",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": "2024-08-15T15:32:12.200605859Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "version": "1302",
+      "taskId": "46418615",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "requestId": "01dc53fd-a74b-491d-99f1-abc19c47ec03",
+        "historySizeBytes": "521"
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": "2024-08-15T15:32:12.367432223Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "version": "1302",
+      "taskId": "46418619",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "workerVersion": {},
+        "sdkMetadata": {
+          "langUsedFlags": [
+            1
+          ]
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": "2024-08-15T15:32:12.367472044Z",
+      "eventType": "EVENT_TYPE_TIMER_STARTED",
+      "version": "1302",
+      "taskId": "46418620",
+      "timerStartedEventAttributes": {
+        "timerId": "c93ef46e-933a-36b2-9b2c-ee85052eee97",
+        "startToFireTimeout": "5s",
+        "workflowTaskCompletedEventId": "4"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": "2024-08-15T15:32:17.369229498Z",
+      "eventType": "EVENT_TYPE_TIMER_FIRED",
+      "version": "1302",
+      "taskId": "46418624",
+      "timerFiredEventAttributes": {
+        "timerId": "c93ef46e-933a-36b2-9b2c-ee85052eee97",
+        "startedEventId": "5"
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": "2024-08-15T15:32:17.369234949Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "version": "1302",
+      "taskId": "46418625",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "33773@Steves-MacBook-Pro.local:c60cb0f8-7c14-4f5f-8195-9884ec14a945",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "MoneyTransferSampleJava24"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": "2024-08-15T15:32:17.377191110Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "version": "1302",
+      "taskId": "46418629",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "7",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "requestId": "9c8bacac-22d6-4321-af25-05629e2329ba",
+        "historySizeBytes": "983"
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": "2024-08-15T15:32:17.416301759Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "version": "1302",
+      "taskId": "46418634",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "7",
+        "startedEventId": "8",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "workerVersion": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": "2024-08-15T15:32:17.416358769Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "version": "1302",
+      "taskId": "46418635",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "62e4434c-8b84-3b33-b935-02c872027f62",
+        "activityType": {
+          "name": "Validate"
+        },
+        "taskQueue": {
+          "name": "MoneyTransferSampleJava24",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IkhBUFBZX1BBVEgi"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "5s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "9",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s",
+          "nonRetryableErrorTypes": [
+            "io.temporal.samples.moneytransfer.AccountTransferActivitiesImpl$InvalidAccountException"
+          ]
+        }
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": "2024-08-15T15:32:17.416385450Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "version": "1302",
+      "taskId": "46418638",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "10",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "requestId": "d1b97bfe-10b6-4a7c-8ff1-68e51e3173df",
+        "attempt": 1,
+        "workerVersion": {}
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": "2024-08-15T15:32:17.485566353Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "version": "1302",
+      "taskId": "46418639",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "dHJ1ZQ=="
+            }
+          ]
+        },
+        "scheduledEventId": "10",
+        "startedEventId": "11",
+        "identity": "33773@Steves-MacBook-Pro.local"
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": "2024-08-15T15:32:17.485571653Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "version": "1302",
+      "taskId": "46418640",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "33773@Steves-MacBook-Pro.local:c60cb0f8-7c14-4f5f-8195-9884ec14a945",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "MoneyTransferSampleJava24"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": "2024-08-15T15:32:17.491890556Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "version": "1302",
+      "taskId": "46418644",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "13",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "requestId": "2b9207d7-10e4-4a9d-b235-104081fb2af9",
+        "historySizeBytes": "2096"
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": "2024-08-15T15:32:17.559697634Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "version": "1302",
+      "taskId": "46418649",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "13",
+        "startedEventId": "14",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "workerVersion": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": "2024-08-15T15:32:17.559738375Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "version": "1302",
+      "taskId": "46418650",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "cb6a03ac-381b-36d5-8b20-b81a1989f47c",
+        "activityType": {
+          "name": "Withdraw"
+        },
+        "taskQueue": {
+          "name": "MoneyTransferSampleJava24",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "MS4w"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IkhBUFBZX1BBVEgi"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "5s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "15",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s",
+          "nonRetryableErrorTypes": [
+            "io.temporal.samples.moneytransfer.AccountTransferActivitiesImpl$InvalidAccountException"
+          ]
+        }
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": "2024-08-15T15:32:17.559767594Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "version": "1302",
+      "taskId": "46418653",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "16",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "requestId": "bbe67b63-a63a-468f-8e68-890be59568ae",
+        "attempt": 1,
+        "workerVersion": {}
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": "2024-08-15T15:32:17.591605021Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "version": "1302",
+      "taskId": "46418654",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IlNVQ0NFU1Mi"
+            }
+          ]
+        },
+        "scheduledEventId": "16",
+        "startedEventId": "17",
+        "identity": "33773@Steves-MacBook-Pro.local"
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": "2024-08-15T15:32:17.591610021Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "version": "1302",
+      "taskId": "46418655",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "33773@Steves-MacBook-Pro.local:c60cb0f8-7c14-4f5f-8195-9884ec14a945",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "MoneyTransferSampleJava24"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": "2024-08-15T15:32:17.600744085Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "version": "1302",
+      "taskId": "46418659",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "19",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "requestId": "f5bb8279-59fd-4aea-aa5a-4d0935d73bdb",
+        "historySizeBytes": "3401"
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": "2024-08-15T15:32:17.664872341Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "version": "1302",
+      "taskId": "46418663",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "19",
+        "startedEventId": "20",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "workerVersion": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": "2024-08-15T15:32:17.664894462Z",
+      "eventType": "EVENT_TYPE_TIMER_STARTED",
+      "version": "1302",
+      "taskId": "46418664",
+      "timerStartedEventAttributes": {
+        "timerId": "9845cd9e-3beb-3ee9-afb2-62cf4254e732",
+        "startToFireTimeout": "2s",
+        "workflowTaskCompletedEventId": "21"
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": "2024-08-15T15:32:19.666178466Z",
+      "eventType": "EVENT_TYPE_TIMER_FIRED",
+      "version": "1302",
+      "taskId": "46418667",
+      "timerFiredEventAttributes": {
+        "timerId": "9845cd9e-3beb-3ee9-afb2-62cf4254e732",
+        "startedEventId": "22"
+      }
+    },
+    {
+      "eventId": "24",
+      "eventTime": "2024-08-15T15:32:19.666186636Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "version": "1302",
+      "taskId": "46418668",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "33773@Steves-MacBook-Pro.local:c60cb0f8-7c14-4f5f-8195-9884ec14a945",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "MoneyTransferSampleJava24"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "25",
+      "eventTime": "2024-08-15T15:32:19.672853603Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "version": "1302",
+      "taskId": "46418672",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "24",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "requestId": "3d7eff99-2e52-439b-ac14-9c8bf1f1551a",
+        "historySizeBytes": "3859"
+      }
+    },
+    {
+      "eventId": "26",
+      "eventTime": "2024-08-15T15:32:19.740742151Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "version": "1302",
+      "taskId": "46418677",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "24",
+        "startedEventId": "25",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "workerVersion": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "27",
+      "eventTime": "2024-08-15T15:32:19.740789172Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "version": "1302",
+      "taskId": "46418678",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "05a2d162-5da8-375a-9ffd-3c7d2a6a6a09",
+        "activityType": {
+          "name": "Deposit"
+        },
+        "taskQueue": {
+          "name": "MoneyTransferSampleJava24",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IjY2Y2E3NDhlLWNhMjMtMzk4NC04MzEyLWNiZjZhY2FlMTUzMiI="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "MS4w"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IkhBUFBZX1BBVEgi"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": "0s",
+        "scheduleToStartTimeout": "0s",
+        "startToCloseTimeout": "5s",
+        "heartbeatTimeout": "0s",
+        "workflowTaskCompletedEventId": "26",
+        "retryPolicy": {
+          "initialInterval": "1s",
+          "backoffCoefficient": 2,
+          "maximumInterval": "100s",
+          "nonRetryableErrorTypes": [
+            "io.temporal.samples.moneytransfer.AccountTransferActivitiesImpl$InvalidAccountException"
+          ]
+        }
+      }
+    },
+    {
+      "eventId": "28",
+      "eventTime": "2024-08-15T15:32:19.740823443Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "version": "1302",
+      "taskId": "46418681",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "27",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "requestId": "a5efebac-9d32-4110-9ee6-c8875c39dc11",
+        "attempt": 1,
+        "workerVersion": {}
+      }
+    },
+    {
+      "eventId": "29",
+      "eventTime": "2024-08-15T15:32:19.772822829Z",
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "version": "1302",
+      "taskId": "46418682",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJjaGFyZ2VJZCI6ImV4YW1wbGUtY2hhcmdlLWlkIn0="
+            }
+          ]
+        },
+        "scheduledEventId": "27",
+        "startedEventId": "28",
+        "identity": "33773@Steves-MacBook-Pro.local"
+      }
+    },
+    {
+      "eventId": "30",
+      "eventTime": "2024-08-15T15:32:19.772830740Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "version": "1302",
+      "taskId": "46418683",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "33773@Steves-MacBook-Pro.local:c60cb0f8-7c14-4f5f-8195-9884ec14a945",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "MoneyTransferSampleJava24"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "31",
+      "eventTime": "2024-08-15T15:32:19.779773930Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "version": "1302",
+      "taskId": "46418687",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "30",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "requestId": "360e495c-44e7-45a3-a697-17c38fcdcf30",
+        "historySizeBytes": "5408"
+      }
+    },
+    {
+      "eventId": "32",
+      "eventTime": "2024-08-15T15:32:19.843527221Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "version": "1302",
+      "taskId": "46418691",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "30",
+        "startedEventId": "31",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "workerVersion": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "33",
+      "eventTime": "2024-08-15T15:32:19.843555622Z",
+      "eventType": "EVENT_TYPE_TIMER_STARTED",
+      "version": "1302",
+      "taskId": "46418692",
+      "timerStartedEventAttributes": {
+        "timerId": "8e437b0d-7db2-3600-99a1-e6ed5b8bd9ab",
+        "startToFireTimeout": "6s",
+        "workflowTaskCompletedEventId": "32"
+      }
+    },
+    {
+      "eventId": "34",
+      "eventTime": "2024-08-15T15:32:25.845527461Z",
+      "eventType": "EVENT_TYPE_TIMER_FIRED",
+      "version": "1302",
+      "taskId": "46418695",
+      "timerFiredEventAttributes": {
+        "timerId": "8e437b0d-7db2-3600-99a1-e6ed5b8bd9ab",
+        "startedEventId": "33"
+      }
+    },
+    {
+      "eventId": "35",
+      "eventTime": "2024-08-15T15:32:25.845533721Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "version": "1302",
+      "taskId": "46418696",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "33773@Steves-MacBook-Pro.local:c60cb0f8-7c14-4f5f-8195-9884ec14a945",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "MoneyTransferSampleJava24"
+        },
+        "startToCloseTimeout": "10s",
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "36",
+      "eventTime": "2024-08-15T15:32:25.858103346Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "version": "1302",
+      "taskId": "46418700",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "35",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "requestId": "0507c679-8876-4a45-a756-0937fa908547",
+        "historySizeBytes": "5866"
+      }
+    },
+    {
+      "eventId": "37",
+      "eventTime": "2024-08-15T15:32:25.893783405Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "version": "1302",
+      "taskId": "46418704",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "35",
+        "startedEventId": "36",
+        "identity": "33773@Steves-MacBook-Pro.local",
+        "workerVersion": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "38",
+      "eventTime": "2024-08-15T15:32:25.893824235Z",
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "version": "1302",
+      "taskId": "46418705",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJjaGFyZ2VSZXNwb25zZU9iaiI6eyJjaGFyZ2VJZCI6ImV4YW1wbGUtY2hhcmdlLWlkIn19"
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "37"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Downloaded histories in Temporal Cloud have events in the "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED" format instead of "WorkflowExecutionStarted". I added a history example compatible with the workflow Replayer, and upgraded the Java SDK (1.24.3) so it succeeds with this new history format.